### PR TITLE
[#48] Renamed OAuth parameter names

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -97,5 +97,5 @@ hwi_oauth:
     resource_owners:
         github:
             type:                github
-            client_id:           "%client_id%"
-            client_secret:       "%client_secret%"
+            client_id:           "%client.id%"
+            client_secret:       "%client.secret%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -18,5 +18,5 @@ parameters:
 
     # A secret key that's used to generate certain security-related tokens
     secret:            ThisTokenIsNotSoSecretChangeIt
-    client_id:         71473a4676970c0dfa36
-    client_secret:     4fa4ce713c55ee8fa7f1ff833327ef3d7f528de8
+    client.id:         71473a4676970c0dfa36
+    client.secret:     4fa4ce713c55ee8fa7f1ff833327ef3d7f528de8


### PR DESCRIPTION
As described in symfony docs
http://symfony.com/doc/current/cookbook/configuration/external_parameter
s.html

Not sure why the DB parameters work slightly differently :confused: 