### PR TITLE
Add php5.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 php:
   - 5.5
+  - 5.6
+  - 7
 
 before_install:
   - mysql -e "create database IF NOT EXISTS dashboardhub;" -uroot

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ language: php
 php:
   - 5.5
   - 5.6
-  - 7
+
+matrix:
+  allowed_failures:
+    - php: 7.0
+  fast_finish: true
 
 before_install:
   - mysql -e "create database IF NOT EXISTS dashboardhub;" -uroot


### PR DESCRIPTION
Travis config updated to have 5.6 support and experimental 7.0 support as an allowed failure

Added fast_finish flag to ensure if one build fails the rest are terminated and the whole build flagged as a failure