### PR TITLE
#289 Badge for DashboardHub environment to be used in maREADME markdown

### DIFF
--- a/web/src/app/main/content/environment/environment-view/environment-view.component.html
+++ b/web/src/app/main/content/environment/environment-view/environment-view.component.html
@@ -45,7 +45,18 @@
         <div fxLayout="column">
           <app-environment-details></app-environment-details>
 
-          <p class="p-24 pb-24">Here are the commands available to you to update your <b>DashboardHub</b> environment from your local machine or from your Continuous Integration environment.</p>
+          <mat-divider></mat-divider>
+
+          <div class="p-24">
+            <p>Your badge to the public view of your environment.</p>
+
+            <p><img src="https://img.shields.io/badge/DashboardHub-{{ environment.title }}-orange.svg" /></p>
+            <markdown>`[![DashboardHub Badge](https://img.shields.io/badge/DashboardHub-{{ environment.title.replace(' ', '%20') }}-orange.svg)]({{ web }}/{{ environment.id }}/view)`</markdown>
+          </div>
+
+          <mat-divider></mat-divider>
+
+          <p class="p-24">Here are the commands available to you to update your <b>DashboardHub</b> environment from your local machine or from your Continuous Integration environment.</p>
 
           <mat-card *ngIf="['build', 'build-deploy'].includes(environment.type)">
             <mat-card-header>

--- a/web/src/app/main/content/environment/environment-view/environment-view.component.ts
+++ b/web/src/app/main/content/environment/environment-view/environment-view.component.ts
@@ -13,6 +13,7 @@ export class EnvironmentViewComponent implements OnInit {
 
   environment: Environment = new Environment('');
   private url: string = environment.api;
+  public web: string = environment.web;
 
   constructor(private route: ActivatedRoute) {
   }

--- a/web/src/app/main/content/help/help.component.ts
+++ b/web/src/app/main/content/help/help.component.ts
@@ -37,6 +37,10 @@ export class HelpComponent
         {
           title: 'Delete environment',
           path: 'coming-soon'
+        },
+        {
+          title: 'Badges',
+          path: 'coming-soon'
         }
       ]
     },


### PR DESCRIPTION
#RELATES TO #289 

### Notes

A summary of what was achieved in this PR

- [ ] ~~API: Task One (eg. updated `deployed` model )~~
- [x] UI: Example badge added to Environment overview page
- [x] Documentation: Updated accordingly - place holder added

<img width="1337" alt="screenshot 2018-02-10 09 18 40" src="https://user-images.githubusercontent.com/624760/36060532-69083e42-0e43-11e8-89e3-cb8538374f56.png">

