### PR TITLE
fix(monitoring): ping not to update timestamp on environment

### DIFF
--- a/api/environments/monitors/pinged/ping.js
+++ b/api/environments/monitors/pinged/ping.js
@@ -97,7 +97,7 @@ module.exports.ping = (event, context, callback) => {
                     environmentModel.model.update({ id }, {
                         pings: { valid: item.isValid ? environment.pings.valid + 1 : environment.pings.valid, invalid: !item.isValid ? environment.pings.invalid + 1 : environment.pings.invalid },
                         latestPing: pinged
-                    }, function (err) {
+                    }, { updateTimestamps: false }, function (err) {
                         if (err) {
                             console.log(err);
                             switch(err.name) {


### PR DESCRIPTION
RELATES TO # {issue_number}

### Notes

A summary of what was achieved in this PR

- [ ] API: Task One (eg. updated `deployed` model )
- [ ] UI: Task Three (eg. added validation rules on create environment page)
- [ ] Documentation: Updated accordingly
