### PR TITLE
fix(tokens): #886 curl example with host

### DIFF
--- a/web/src/app/environments/tokens/environments-tokens.component.ts
+++ b/web/src/app/environments/tokens/environments-tokens.component.ts
@@ -8,6 +8,8 @@ import { Token } from './token.model';
 import { TokenService } from './token.service';
 import { DialogMarkdownComponent } from '../../dialog/markdown/dialog-markdown.component';
 
+import { environment } from '../../../environments/environment';
+
 @Component({
   selector: 'qs-environments-tokens',
   templateUrl: './environments-tokens.component.html',
@@ -86,7 +88,7 @@ export class EnvironmentsTokensComponent implements OnInit {
         curl -XPOST \\
            -H "Content-Type: application/json" \\
            -d '{ "release":"vX.Y.Z" }' \\
-           /environments/${this.environmentId}/deployed/${token.id}/${state}
+           ${environment.api}/environments/${this.environmentId}/deployed/${token.id}/${state}
         \`\`\`
         `;
 


### PR DESCRIPTION
closes #886 

### Notes

The host in the url will match the API environment that is being used (e.g. `localhost:3000`, `pipeline-test.dashboardhub.io` etc)

- [ ] API: Task One (eg. updated `deployed` model )
- [ ] UI: Task Three (eg. added validation rules on create environment page)
- [ ] Documentation: Updated accordingly

<img width="900" alt="screenshot 2018-05-22 08 59 50" src="https://user-images.githubusercontent.com/624760/40349448-8c4b0cfe-5d9e-11e8-98d9-0d421a91fd56.png">
