### PR TITLE
fix(badges): #1008 url encode environment name for badge url

### DIFF
--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -81,6 +81,7 @@ import { Angulartics2Module } from 'angulartics2';
 import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
 import { ReleaseService } from './environments/releases/release.service';
 import { ReleasesResolver } from './environments/releases/releases.resolve';
+import { EncodeUriPipe } from './pipes/urlencode.pipe';
 
 export function tokenGetter(): string | null {
   return localStorage.getItem('access_token');
@@ -104,6 +105,7 @@ export function tokenGetter(): string | null {
     EnvironmentsViewComponent,
     EnvironmentsViewPrivateComponent,
     EnvironmentsViewPublicComponent,
+    EncodeUriPipe,
     FeaturesComponent,
     HelpComponent,
     LoginComponent,

--- a/web/src/app/environments/view/private/environments-view-private.component.html
+++ b/web/src/app/environments/view/private/environments-view-private.component.html
@@ -22,7 +22,7 @@
 
       <td-markdown>
         ```
-        [![DashboardHub Badge](https://img.shields.io/badge/DashboardHub-{{ environment.title }}-orange.svg)](https://pipeline.dashboardhub.io/{{ environment.id }}/view)
+        [![DashboardHub Badge](https://img.shields.io/badge/DashboardHub-{{ environment.title | encodeUri }}-orange.svg)](https://pipeline.dashboardhub.io/environments/{{ environment.id }}/view)
         ```
       </td-markdown>
     </mat-card-content>

--- a/web/src/app/pipes/urlencode.pipe.ts
+++ b/web/src/app/pipes/urlencode.pipe.ts
@@ -1,0 +1,8 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'encodeUri' })
+export class EncodeUriPipe implements PipeTransform {
+  transform(uri: string): string {
+    return encodeURI(uri);
+  }
+}


### PR DESCRIPTION
closes #1008 

### Notes

A summary of what was achieved in this PR

- [ ] API: Task One (eg. updated `deployed` model )
- [ ] UI: Task Three (eg. added validation rules on create environment page)
- [ ] Documentation: Updated accordingly
