### PR TITLE
feat(footer): fix link to website and feedback button hiding logo

### DIFF
--- a/web/src/app/main.component.html
+++ b/web/src/app/main.component.html
@@ -61,8 +61,9 @@
     <router-outlet></router-outlet>
     <td-layout-footer>
       <div layout="row" layout-align="start center">
-        <span class="mat-caption">Copyright &copy; 2018 DashboardHub. All rights reserved <i>({{ version }})</i></span>
+        <span class="mat-caption">Copyright &copy; 2018 <a href="https://www.dashboardhub.io" target="_blank" rel="noopener">DashboardHub</a>. All rights reserved <i>({{ version }})</i></span>
         <span flex></span>
+        <button mat-button (click)="showDoorbell()" color="accent">Feedback</button>
         <mat-icon class="mat-icon-ux" svgIcon="assets:dashboardhub"></mat-icon>
       </div>
     </td-layout-footer>

--- a/web/src/app/main.component.ts
+++ b/web/src/app/main.component.ts
@@ -87,6 +87,10 @@ export class MainComponent {
     }
   }
 
+  showDoorbell() {
+    (<any>window).doorbell.show();
+  }
+
   logout(): void {
     this.authService.logout();
     this.router.navigate(['/logout']);

--- a/web/src/environments/environment.ts
+++ b/web/src/environments/environment.ts
@@ -2,8 +2,8 @@ import { Config } from './config.model';
 
 export const environment: Config = {
   production: false,
-  api: 'https://api-pipeline.dashboardhub.io',
-  web: 'https://pipeline.dashboardhub.io',
+  api: 'http://localhost:3000',
+  web: 'http://localhost:4200',
   whitelist: new Array(new RegExp('^null$')),
   version: 'x.x.x',
 

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -29,7 +29,8 @@
   <script type="text/javascript">
     window.doorbellOptions = {
       id: '9245',
-      appKey: 'r9Nveuhwkq0vZIcO5yEBVBTSadlhhqMdXbSnzJZqswcfGfkBCerejrLEIVjlJPbS'
+      appKey: 'r9Nveuhwkq0vZIcO5yEBVBTSadlhhqMdXbSnzJZqswcfGfkBCerejrLEIVjlJPbS',
+      hideButton: true
     };
     (function(w, d, t) {
       var hasLoaded = false;

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -1,3 +1,8 @@
+@import '~@angular/material/theming';
+@import './theme';
+
+@include mat-core();
+
 // Custom style for loading elements without height
 .will-load {
     min-height: 80px;
@@ -5,4 +10,13 @@
 // Href line height wasn't right for mat-icon-button
 a[mat-icon-button] {
     line-height: 36px;
+}
+
+a {
+  color: mat-color($accent, 900);
+  text-decoration: none;
+
+  &:hover, &:active, &:focus {
+    color: mat-color($accent, 700);
+  }
 }


### PR DESCRIPTION
RELATES TO #1050 and #1057 

### Notes

A summary of what was achieved in this PR

- [x] Feedback button now integrated with the footer links vs "hovering"
- [x] DashboardHub website link from footer
- [x] All anchor links are now the DH orange colour

![screen shot 2018-10-08 at 20 48 46](https://user-images.githubusercontent.com/773633/46630555-6fdc8780-cb3c-11e8-9a5a-e31622ddf6fd.png)
