### PR TITLE
chore(project): #1165, #1164, #1174 Refactored app routing module and…

### DIFF
--- a/web/src/app/app-material.module.ts
+++ b/web/src/app/app-material.module.ts
@@ -20,8 +20,6 @@ import {
     MatRadioModule,
 } from '@angular/material';
 
-import { FlexLayoutModule } from '@angular/flex-layout';
-
 @NgModule({
     imports: [
         MatBadgeModule,
@@ -41,7 +39,6 @@ import { FlexLayoutModule } from '@angular/flex-layout';
         MatTabsModule,
         MatToolbarModule,
         MatTooltipModule,
-        FlexLayoutModule,
     ],
     exports: [
         MatBadgeModule,
@@ -61,8 +58,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
         MatTabsModule,
         MatToolbarModule,
         MatTooltipModule,
-        FlexLayoutModule,
     ]
 })
-export class MaterialModule {
+export class AppMaterialModule {
 }

--- a/web/src/app/app-routing.module.ts
+++ b/web/src/app/app-routing.module.ts
@@ -1,20 +1,21 @@
-import { HomepageComponent } from './homepage/homepage.component';
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
+// Authentication guards for dashboard hub app module
+import { AuthGuard } from '../guards/authentication.guard';
+
+// Dashboard hub app module components
+import { EditProjectComponent } from './projects/edit/edit.component';
+import { CreateProjectComponent } from './projects/create/create.component';
 import { MainComponent } from './main.component';
 import { FeaturesComponent } from './features/features.component';
 import { HelpComponent } from './help/help.component';
-import { PrivacyComponent } from './legal/privacy/privacy.component';
-import { TermsConditionsComponent } from './legal/terms-conditions/terms-conditions.component';
-
-import { PrivateProjectsComponent } from './projects/private/private.component';
-import { AuthGuard } from '../guards/authentication.guard';
-// import { ProfileResolver } from '../resolvers/profile.resolver';
+import { HomepageComponent } from './homepage/homepage.component';
 import { ProfileComponent } from './profile/profile.component';
-import { CreateProjectComponent } from './projects/create/create.component';
+import { PrivacyComponent } from './legal/privacy/privacy.component';
+import { PrivateProjectsComponent } from './projects/private/private.component';
+import { TermsConditionsComponent } from './legal/terms-conditions/terms-conditions.component';
 import { ViewProjectComponent } from './projects/view/view.component';
-import { EditProjectComponent } from './projects/edit/edit.component';
 
 const routes: Routes = [
     {
@@ -24,37 +25,35 @@ const routes: Routes = [
         children: [
             {
                 path: '',
-                component: HomepageComponent,
+                component: HomepageComponent
             },
             {
                 path: 'projects/create',
                 pathMatch: 'full',
                 component: CreateProjectComponent,
-                canActivate: [AuthGuard],
+                canActivate: [AuthGuard]
             },
             {
                 path: 'project/:uid',
                 pathMatch: 'full',
                 component: ViewProjectComponent,
-                // canActivate: [AuthGuard],
             },
             {
                 path: 'project/:uid/edit',
                 pathMatch: 'full',
                 component: EditProjectComponent,
-                // canActivate: [AuthGuard],
             },
             {
                 path: 'projects',
                 pathMatch: 'full',
                 component: PrivateProjectsComponent,
-                canActivate: [AuthGuard],
+                canActivate: [AuthGuard]
             },
             {
                 path: 'profile',
                 pathMatch: 'full',
                 component: ProfileComponent,
-                canActivate: [AuthGuard],
+                canActivate: [AuthGuard]
             },
             {
                 path: 'features',
@@ -64,7 +63,7 @@ const routes: Routes = [
             {
                 path: 'help',
                 pathMatch: 'full',
-                component: HelpComponent,
+                component: HelpComponent
             },
             {
                 path: 'terms-and-conditions',
@@ -74,20 +73,15 @@ const routes: Routes = [
             {
                 path: 'privacy',
                 pathMatch: 'full',
-                component: PrivacyComponent,
+                component: PrivacyComponent
             },
-            { path: '**', redirectTo: '/' },
+            { path: '**', redirectTo: '/' }
         ]
     }
 ];
 
 @NgModule({
-    imports: [
-        RouterModule.forRoot(routes)
-    ],
-    exports: [
-        RouterModule
-    ]
+    imports: [RouterModule.forRoot(routes)],
+    exports: [RouterModule]
 })
-export class AppRoutesModule {
-}
+export class AppRoutingModule {}

--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -4,42 +4,46 @@ import { HttpClientModule } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
 import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { environment } from '../environments/environment';
+
+// Third party modules
 import { AngularFireModule } from '@angular/fire';
 import { AngularFirestoreModule } from '@angular/fire/firestore';
 import { AngularFireAuthModule } from '@angular/fire/auth';
 import { DeviceDetectorModule } from 'ngx-device-detector';
+import { AngularFireFunctionsModule, FunctionsRegionToken } from '@angular/fire/functions';
 
-import { environment } from '../environments/environment';
+// Dashboard hub modules
+import { AppRoutingModule } from './app-routing.module';
+import { GitHubHttpInterceptorModule } from '../interceptors/github.http.interceptor';
+import { ErrorHttpInterceptorModule } from '../interceptors/error.http.interceptor';
+import { PipesModule } from '../pipes/pipes.module';
+import { SharedModule } from './shared/shared.module';
 
-import { MarkdownDirective } from './directives/markdown.directive';
-
+// Dashboard hub components
 import { AppComponent } from './app.component';
-import { MainComponent } from './main.component';
+import { CreateProjectComponent } from './projects/create/create.component';
+import { DialogListComponent } from './dialog/list/dialog-list.component';
+import { EditProjectComponent } from './projects/edit/edit.component';
 import { FeaturesComponent } from './features/features.component';
 import { HelpComponent } from './help/help.component';
+import { HomepageComponent } from './homepage/homepage.component';
+import { MainComponent } from './main.component';
+import { PublicProjectsComponent } from './projects/public/public.component';
 import { PrivacyComponent } from './legal/privacy/privacy.component';
+import { PrivateProjectsComponent } from './projects/private/private.component';
+import { ProfileComponent } from './profile/profile.component';
+import { ProjectsComponent } from './projects/projects.component';
+import { RepositoryComponent } from './projects/repository/repository.component';
 import { TermsConditionsComponent } from './legal/terms-conditions/terms-conditions.component';
+import { ViewProjectComponent } from './projects/view/view.component';
 
+// Dashboard hub dialog components
 import { DialogConfirmationComponent } from './dialog/confirmation/dialog-confirmation.component';
 import { DialogMarkdownComponent } from './dialog/markdown/dialog-markdown.component';
 
-import { GitHubHttpInterceptorModule } from '../interceptors/github.http.interceptor';
-import { ErrorHttpInterceptorModule } from '../interceptors/error.http.interceptor';
-
-import { PipesModule } from '../pipes/pipes.module';
-import { MaterialModule } from './material.module';
-import { AppRoutesModule } from './routes.module';
-import { PrivateProjectsComponent } from './projects/private/private.component';
-import { ProfileComponent } from './profile/profile.component';
-import { CreateProjectComponent } from './projects/create/create.component';
-import { PublicProjectsComponent } from './projects/public/public.component';
-import { ProjectsComponent } from './projects/projects.component';
-import { ViewProjectComponent } from './projects/view/view.component';
-import { EditProjectComponent } from './projects/edit/edit.component';
-import { DialogListComponent } from './dialog/list/dialog-list.component';
-import { RepositoryComponent } from './projects/repository/repository.component';
-import { AngularFireFunctionsModule, FunctionsRegionToken } from '@angular/fire/functions';
-import { HomepageComponent } from './homepage/homepage.component';
+// Dashboard hub directive 
+import { MarkdownDirective } from './directives/markdown.directive';
 
 export function tokenGetter(): string | null {
     return localStorage.getItem('access_token');
@@ -72,17 +76,17 @@ export function tokenGetter(): string | null {
         AngularFireModule.initializeApp(environment.firebase),
         AngularFirestoreModule.enablePersistence(),
         AngularFireFunctionsModule,
+        BrowserAnimationsModule,
         CommonModule,
         DeviceDetectorModule.forRoot(),
         HttpClientModule,
         RouterModule,
         ReactiveFormsModule,
-        BrowserAnimationsModule,
-        MaterialModule,
-        PipesModule,
-        AppRoutesModule,
-        GitHubHttpInterceptorModule,
+        AppRoutingModule,
         ErrorHttpInterceptorModule,
+        GitHubHttpInterceptorModule,
+        PipesModule,
+        SharedModule
     ],
     providers: [
         { provide: FunctionsRegionToken, useValue: 'us-central1' }

--- a/web/src/app/shared/shared.module.ts
+++ b/web/src/app/shared/shared.module.ts
@@ -1,0 +1,15 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+// Third party module
+import { FlexLayoutModule } from '@angular/flex-layout';
+
+// Dashboard hub App modules
+import { AppMaterialModule } from '../app-material.module';
+
+@NgModule({
+    declarations: [],
+    imports: [CommonModule, FlexLayoutModule, AppMaterialModule],
+    exports: [FlexLayoutModule, AppMaterialModule]
+})
+export class SharedModule {}


### PR DESCRIPTION
closes #1165 
closes #1164
closes #1174 

### Notes

A summary of what was achieved in this PR

- [] Renamed routes.module.ts to app-routing.module.ts as per standard naming conventions
- [] Refactored app-routing.module.ts by grouping all imports and set them in alphabetical order
- [] Renamed material.module.ts to app-material.module.ts as per standard naming conventions
- [] Removed flex layout import from app-material.module.ts 
- [] Created shared module for importing all common modules like AppMaterialModule and FlexLayoutModule
-[] Right now we have only one app module so we have imported shared module into app module only, once we will start creating feature modules then we can import shared module in them. So that we can import common modules in one place instead of importing them in each feature module.
-[] Refactored app module by grouping all imports and set them in alphabetical order

Kindly review and let me know if you have any questions 