### PR TITLE
feat(homepage): #1206 Show user username if name not available

### DIFF
--- a/web/src/app/main/components/homepage/homepage.component.html
+++ b/web/src/app/main/components/homepage/homepage.component.html
@@ -9,7 +9,7 @@
                 <mat-list fxFlex dense>
                     <mat-list-item *ngFor="let user of users">
                         <img matListAvatar [src]="user.avatarUrl" [alt]="user.username" />
-                        <h4 mat-line>{{ user.name }} ({{ user.username }})</h4>
+                        <h4 mat-line><a href="https://github.com/{{user.username}}">{{ user.name ? user.name : user.username }}</a></h4>
                         <p mat-line>{{ user.github.activity.latest.type }} on {{ user.github.activity.latest.repository.fullName }} at {{ user.lastUpdated.toDate() | timeAgo }}</p>
                     </mat-list-item>
                 </mat-list>


### PR DESCRIPTION
closes #1206 
closes #1208 

Changes
- If `name` is not available, show `username`
- Linked added to user / username

<img width="600" alt="Screenshot 2019-05-04 at 22 18 57" src="https://user-images.githubusercontent.com/624760/57184905-a99b2400-6eba-11e9-976a-8b467451041c.png">
