### PR TITLE
 chore(refactor): #1229 move spinner to taps

### DIFF
--- a/web/src/app/core/services/authentication.service.ts
+++ b/web/src/app/core/services/authentication.service.ts
@@ -9,7 +9,7 @@ import { auth, User } from 'firebase/app';
 
 // Rxjs operators
 import { from, Observable, of } from 'rxjs';
-import { filter, concatMap, switchMap, first, takeUntil } from 'rxjs/operators';
+import { filter, concatMap, switchMap, first, takeUntil, tap } from 'rxjs/operators';
 
 // Third party modules
 import { DeviceDetectorService } from 'ngx-device-detector';
@@ -84,11 +84,11 @@ export class AuthenticationService {
 
     // This function used to login via github
     public login(): void {
-        this.spinnerService.setProgressBar(true);
         const provider: auth.GithubAuthProvider = new auth.GithubAuthProvider();
         provider.addScope('repo,admin:repo_hook');
         from(this.afAuth.auth.signInWithPopup(provider))
             .pipe(
+                tap(() => this.spinnerService.setProgressBar(true)),
                 filter((credentials: firebase.auth.UserCredential) => !!credentials),
                 concatMap(
                     (credentials: firebase.auth.UserCredential) => from(credentials.user.getIdTokenResult()),
@@ -135,11 +135,9 @@ export class AuthenticationService {
                         })),
                     (profile: ProfileModel) => this.profile = profile,
                 ),
+                tap(() => this.spinnerService.setProgressBar(false)),
             )
-            .subscribe(() => {
-                this.isAuthenticated = true;
-                this.spinnerService.setProgressBar(false);
-            });
+            .subscribe(() => this.isAuthenticated = true);
     }
 
     // This function is used for logout from dashboard hub

--- a/web/src/app/main/components/homepage/homepage.component.ts
+++ b/web/src/app/main/components/homepage/homepage.component.ts
@@ -4,7 +4,6 @@ import { Subscription } from 'rxjs';
 // Dashboard hub model and services
 import { UserStatsModel } from '../../../shared/models/index.model';
 import { UserService } from '../../../core/services/user.service';
-import { SpinnerService } from '../../../core/services/spinner.service';
 
 @Component({
     selector: 'dashboard-homepage',
@@ -18,7 +17,6 @@ export class HomepageComponent implements OnInit {
 
     constructor(
         private userService: UserService,
-        private spinnerService: SpinnerService
     ) {
     }
 

--- a/web/src/app/shared/components/public/public.component.ts
+++ b/web/src/app/shared/components/public/public.component.ts
@@ -5,7 +5,6 @@ import { Subscription } from 'rxjs';
 import { ProjectModel } from '../../models/index.model';
 import { ProjectService } from '../../../core/services/project.service';
 import { Router } from '@angular/router';
-import { SpinnerService } from '../../../core/services/spinner.service';
 
 @Component({
     selector: 'dashboard-projects-public',
@@ -20,7 +19,6 @@ export class PublicProjectsComponent implements OnInit {
     constructor(
         private projectService: ProjectService,
         private router: Router,
-        private spinnerService: SpinnerService
     ) {
     }
 


### PR DESCRIPTION
closes #1229 

### Notes

A summary of what was achieved in this PR

- [ ] moved spinner to pre/post `tap` - looks the same, starts slightly later and finishes the same time
- [ ] removed unused spinner imports
