### PR TITLE
feat(repositories)#1124 add git webhook to repository

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,8 +15,10 @@
   "main": "lib/index.js",
   "dependencies": {
     "@google-cloud/logging-winston": "^1.0.0",
-    "firebase-admin": "^7.4.0",
-    "firebase-functions": "^2.3.1",
+    "cors": "^2.8.5",
+    "express": "^4.17.1",
+    "firebase-admin": "^8.2.0",
+    "firebase-functions": "^3.0.2",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "winston": "^3.2.1"

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@google-cloud/logging-winston": "^1.0.0",
     "cors": "^2.8.5",
-    "express": "^4.17.1",
     "firebase-admin": "^8.2.0",
     "firebase-functions": "^3.1.0",
     "request": "^2.88.0",
@@ -25,6 +24,7 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.5",
     "@types/request-promise-native": "^1.0.16",
     "firebase-functions-test": "^0.1.6",
     "tslint": "~5.16.0",

--- a/functions/src/client/firebase-admin.ts
+++ b/functions/src/client/firebase-admin.ts
@@ -7,3 +7,5 @@ export declare type DocumentData = admin.firestore.DocumentData;
 export declare type WriteResult = admin.firestore.WriteResult;
 export declare type QuerySnapshot = admin.firestore.QuerySnapshot;
 export declare type QueryDocumentSnapshot = admin.firestore.QueryDocumentSnapshot;
+export declare type DocumentReference = admin.firestore.DocumentReference;
+

--- a/functions/src/client/github.ts
+++ b/functions/src/client/github.ts
@@ -1,4 +1,4 @@
-import { get, post } from 'request-promise-native';
+import { delete as del, get, post } from 'request-promise-native';
 
 export async function GitHubClient<T>(uri: string, token: string): Promise<T> {
   return <T>await get({
@@ -20,5 +20,15 @@ export async function GitHubClientPost<T>(uri: string, token: string, body: any)
     },
     json: true,
     body: body,
+  });
+};
+
+export async function GitHubClientDelete<T>(uri: string, token: string): Promise<T> {
+  return <T>await del({
+    uri: `https://api.github.com${uri}`,
+    headers: {
+      'User-Agent': 'DashboardHub',
+      'Authorization': `token ${token}`,
+    },
   });
 };

--- a/functions/src/client/github.ts
+++ b/functions/src/client/github.ts
@@ -1,4 +1,4 @@
-import { get } from 'request-promise-native';
+import { get, post } from 'request-promise-native';
 
 export async function GitHubClient<T>(uri: string, token: string): Promise<T> {
   return <T>await get({
@@ -8,5 +8,17 @@ export async function GitHubClient<T>(uri: string, token: string): Promise<T> {
       'Authorization': `token ${token}`,
     },
     json: true,
+  });
+};
+
+export async function GitHubClientPost<T>(uri: string, token: string, body: any): Promise<T> {
+  return <T>await post({
+    uri: `https://api.github.com${uri}`,
+    headers: {
+      'User-Agent': 'DashboardHub',
+      'Authorization': `token ${token}`,
+    },
+    json: true,
+    body: body,
   });
 };

--- a/functions/src/environments/environment.ts
+++ b/functions/src/environments/environment.ts
@@ -1,7 +1,11 @@
 
 export const enviroment: Config = {
   githubWebhook: {
-    url: "https://us-central1-pipelinedashboard-dev-cfa68.cloudfunctions.ne/responseGitWebhookRepository",
+    url: "https://us-central1-pipelinedashboard-dev-cfa68.cloudfunctions.net/responseGitWebhookRepository",
+    events: [
+      'push',
+      'pull_request',
+    ],
   },
 
 }
@@ -9,5 +13,6 @@ export const enviroment: Config = {
 interface Config {
   githubWebhook: {
     url: string,
+    events: string[],
   }
 }

--- a/functions/src/environments/environment.ts
+++ b/functions/src/environments/environment.ts
@@ -1,0 +1,13 @@
+
+export const enviroment: Config = {
+  githubWebhook: {
+    url: "https://us-central1-pipelinedashboard-dev-cfa68.cloudfunctions.ne/responseGitWebhookRepository",
+  },
+
+}
+
+interface Config {
+  githubWebhook: {
+    url: string,
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,7 +8,6 @@ import { DocumentSnapshot } from './client/firebase-admin';
 // Dashboard repositories
 import { onCreateGitWebhookRepository, CreateGitWebhookRepositoryInput } from './repository/create-git-webhook-repository';
 import { onCreateRepository } from './repository/create-repository';
-import { onFindGitWebhookRepository, FindGitWebhookRepositoryInput } from './repository/find-git-webhook-repository';
 import { getRepositoryInfo, RepositoryInfoInput } from './repository/info';
 import { onResponseGitWebhookRepository } from './repository/response-git-webhook-repository';
 import { onUpdateRepository } from './repository/update-repository';
@@ -34,7 +33,6 @@ export const findAllUserEvents: HttpsFunction = functions.https.onCall((input: E
 export const findRepositoryInfo: HttpsFunction = functions.https.onCall((input: RepositoryInfoInput, context: CallableContext) => getRepositoryInfo(input.token, input.fullName));
 export const createGitWebhookRepository: HttpsFunction = functions.https.onCall((input: CreateGitWebhookRepositoryInput, context: CallableContext) => onCreateGitWebhookRepository(input.token, input.repositoryUid));
 export const deleteGitWebhookRepository: HttpsFunction = functions.https.onCall((input: DeleteGitWebhookRepositoryInput, context: CallableContext) => onDeleteGitWebhookRepository(input.token, input.repositoryUid));
-export const findGitWebhookRepository: HttpsFunction = functions.https.onCall((input: FindGitWebhookRepositoryInput, context: CallableContext) => onFindGitWebhookRepository(input.token, input.repositoryUid));
 export const responseGitWebhookRepository: HttpsFunction = onResponseGitWebhookRepository;
 export const pingMonitor: HttpsFunction = functions.https.onCall((input: MonitorInfoInput, context: CallableContext) => ping(input.projectUid, input.monitorUid));
 export const deletePings: HttpsFunction = functions.https.onCall((input: MonitorInfoInput, context: CallableContext) => deleteMonitorPings(input.projectUid, input.monitorUid));

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,6 +6,7 @@ import { CallableContext } from 'firebase-functions/lib/providers/https';
 import { DocumentSnapshot } from './client/firebase-admin';
 
 // Dashboard repositories
+import { onCreateGitWebhookRepository, CreateGitWebhookRepositoryInput } from './repository/create-git-webhook-repository';
 import { onCreateRepository } from './repository/create-repository';
 import { getRepositoryInfo, RepositoryInfoInput } from './repository/info';
 import { onUpdateDeleteRepository } from './repository/update-delete-repository';
@@ -18,6 +19,7 @@ import { onUpdateUserStats } from './user/stats';
 // Dashboard projects
 import { onDeleteProjectRepositories } from './project/delete-project';
 import { onUpdateProjectRepositories } from './project/update-repositories';
+import { onResponseGitWebhookRepository } from './repository/response-git-webhook-repository';
 
 declare type HttpsFunction = functions.HttpsFunction;
 declare type CloudFunction<T> = functions.CloudFunction<T>;
@@ -26,6 +28,8 @@ declare type Change<T> = functions.Change<T>;
 export const findAllUserRepositories: HttpsFunction = functions.https.onCall((input: ReposInput, context: CallableContext) => getUserRepos(input.token, context.auth.uid));
 export const findAllUserEvents: HttpsFunction = functions.https.onCall((input: EventsInput, context: CallableContext) => getUserEvents(input.token, context.auth.uid, input.username));
 export const findRepositoryInfo: HttpsFunction = functions.https.onCall((input: RepositoryInfoInput, context: CallableContext) => getRepositoryInfo(input.token, input.fullName));
+export const createGitWebhookRepository: HttpsFunction = functions.https.onCall((input: CreateGitWebhookRepositoryInput, context: CallableContext) => onCreateGitWebhookRepository(input.token, input.repositoryUid));
+export const responseGitWebhookRepository: HttpsFunction = onResponseGitWebhookRepository;
 
 export const deleteProjectRepositories: CloudFunction<DocumentSnapshot> = onDeleteProjectRepositories;
 export const updateProjectRepositories: CloudFunction<DocumentSnapshot> = onUpdateProjectRepositories;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,8 +8,10 @@ import { DocumentSnapshot } from './client/firebase-admin';
 // Dashboard repositories
 import { onCreateGitWebhookRepository, CreateGitWebhookRepositoryInput } from './repository/create-git-webhook-repository';
 import { onCreateRepository } from './repository/create-repository';
+import { onFindGitWebhookRepository, FindGitWebhookRepositoryInput } from './repository/find-git-webhook-repository';
 import { getRepositoryInfo, RepositoryInfoInput } from './repository/info';
-import { onUpdateDeleteRepository } from './repository/update-delete-repository';
+import { onResponseGitWebhookRepository } from './repository/response-git-webhook-repository';
+import { onUpdateRepository } from './repository/update-repository';
 
 // Dashboard users
 import { getUserEvents, EventsInput } from './user/events';
@@ -19,7 +21,8 @@ import { onUpdateUserStats } from './user/stats';
 // Dashboard projects
 import { onDeleteProjectRepositories } from './project/delete-project';
 import { onUpdateProjectRepositories } from './project/update-repositories';
-import { onResponseGitWebhookRepository } from './repository/response-git-webhook-repository';
+import { onDeleteGitWebhookRepository, DeleteGitWebhookRepositoryInput } from './repository/delete-git-webhook-repository';
+
 
 declare type HttpsFunction = functions.HttpsFunction;
 declare type CloudFunction<T> = functions.CloudFunction<T>;
@@ -29,10 +32,12 @@ export const findAllUserRepositories: HttpsFunction = functions.https.onCall((in
 export const findAllUserEvents: HttpsFunction = functions.https.onCall((input: EventsInput, context: CallableContext) => getUserEvents(input.token, context.auth.uid, input.username));
 export const findRepositoryInfo: HttpsFunction = functions.https.onCall((input: RepositoryInfoInput, context: CallableContext) => getRepositoryInfo(input.token, input.fullName));
 export const createGitWebhookRepository: HttpsFunction = functions.https.onCall((input: CreateGitWebhookRepositoryInput, context: CallableContext) => onCreateGitWebhookRepository(input.token, input.repositoryUid));
+export const deleteGitWebhookRepository: HttpsFunction = functions.https.onCall((input: DeleteGitWebhookRepositoryInput, context: CallableContext) => onDeleteGitWebhookRepository(input.token, input.repositoryUid));
+export const findGitWebhookRepository: HttpsFunction = functions.https.onCall((input: FindGitWebhookRepositoryInput, context: CallableContext) => onFindGitWebhookRepository(input.token, input.repositoryUid));
 export const responseGitWebhookRepository: HttpsFunction = onResponseGitWebhookRepository;
 
 export const deleteProjectRepositories: CloudFunction<DocumentSnapshot> = onDeleteProjectRepositories;
 export const updateProjectRepositories: CloudFunction<DocumentSnapshot> = onUpdateProjectRepositories;
-export const updateDeleteRepository: CloudFunction<Change<DocumentSnapshot>> = onUpdateDeleteRepository;
+export const updateRepository: CloudFunction<Change<DocumentSnapshot>> = onUpdateRepository;
 export const createRepository: CloudFunction<DocumentSnapshot> = onCreateRepository;
 export const updateUserStats: CloudFunction<DocumentSnapshot> = onUpdateUserStats;

--- a/functions/src/mappers/github/index.mapper.ts
+++ b/functions/src/mappers/github/index.mapper.ts
@@ -8,3 +8,4 @@ export * from './pullRequest.mapper';
 export * from './release.mapper';
 export * from './repository.mapper';
 export * from './user.mapper';
+export * from './webhook.mapper';

--- a/functions/src/mappers/github/repository.mapper.ts
+++ b/functions/src/mappers/github/repository.mapper.ts
@@ -8,6 +8,7 @@ import { GitHubIssueModel } from './issue.mapper';
 import { GitHubMilestoneModel } from './milestone.mapper';
 import { GitHubPullRequestModel } from './pullRequest.mapper';
 import { GitHubReleaseModel } from './release.mapper';
+import { GitHubRepositoryWebhookModel } from './webhook.mapper';
 
 export interface GitHubRepositoryInput {
   id: string;
@@ -35,6 +36,7 @@ export interface GitHubRepositoryModel {
   contributors?: GitHubContributorModel[];
   milestones?: GitHubMilestoneModel[];
   updatedAt: firestore.Timestamp;
+  webhook?: GitHubRepositoryWebhookModel;
 }
 
 export class GitHubRepositoryMapper {

--- a/functions/src/mappers/github/webhook.mapper.ts
+++ b/functions/src/mappers/github/webhook.mapper.ts
@@ -5,9 +5,10 @@ export interface GitHubRepositoryWebhookResponse {
   active: boolean;
   events: string[];
   config: {
-    content_type: string;
-    insecure_ssl: string;
     url: string;
+    content_type?: 'form' | 'json';
+    secret?: string;
+    insecure_ssl?: '0' | '1';
   };
   updated_at: Date;
   created_at: Date;
@@ -31,5 +32,81 @@ export interface GitHubRepositoryWebhookRequestCreate {
     secret?: string;
     insecure_ssl?: '0' | '1';
 
+  }
+}
+
+export interface GitHubRepositoryWebhookModel {
+  type: string;
+  id: number;
+  name: string;
+  active: boolean;
+  events: string[];
+  config: {
+    url: string;
+    contentType?: 'form' | 'json';
+    secret?: string;
+    insecureSsl?: '0' | '1';
+  };
+  updatedAt: Date;
+  createdAt: Date;
+  url: string;
+  testUrl: string;
+  pingUrl: string;
+  lastResponse: {
+    code?: any;
+    status: string;
+    message?: any;
+  };
+}
+
+export class GitHubRepositoryWebhookMapper {
+  static import(input: GitHubRepositoryWebhookResponse): GitHubRepositoryWebhookModel {
+    let config: any = null;
+    if (input.config) {
+      config = {
+        url: input.config.url,
+      };
+
+      if(input.config.content_type !== undefined){
+        config.contentType = input.config.content_type;
+      }
+      if(input.config.secret !== undefined){
+        config.secret = input.config.secret;
+      }
+      if(input.config.insecure_ssl !== undefined){
+        config.insecureSsl = input.config.insecure_ssl;
+      }
+    }
+
+    let lastResponse: any = null;
+    if (input.last_response) {
+      lastResponse = {
+      };
+
+      if(input.last_response.code !== undefined){
+        lastResponse.code = input.last_response.code;
+      }
+      if(input.last_response.status !== undefined){
+        lastResponse.status = input.last_response.status;
+      }
+      if(input.last_response.message !== undefined){
+        lastResponse.message = input.last_response.message;
+      }
+    }
+
+    return {
+      type: input.type,
+      id: input.id,
+      name: input.name,
+      active: input.active,
+      events: input.events,
+      config: config,
+      updatedAt: input.updated_at,
+      createdAt: input.created_at,
+      url: input.url,
+      testUrl: input.test_url,
+      pingUrl: input.ping_url,
+      lastResponse: lastResponse,
+    };
   }
 }

--- a/functions/src/mappers/github/webhook.mapper.ts
+++ b/functions/src/mappers/github/webhook.mapper.ts
@@ -1,0 +1,35 @@
+export interface GitHubRepositoryWebhookResponse {
+  type: string;
+  id: number;
+  name: string;
+  active: boolean;
+  events: string[];
+  config: {
+    content_type: string;
+    insecure_ssl: string;
+    url: string;
+  };
+  updated_at: Date;
+  created_at: Date;
+  url: string;
+  test_url: string;
+  ping_url: string;
+  last_response: {
+    code?: any;
+    status: string;
+    message?: any;
+  };
+}
+
+export interface GitHubRepositoryWebhookRequestCreate {
+  name: string;
+  active?: boolean;
+  events?: string[];
+  config: {
+    url: string;
+    content_type?: 'form' | 'json';
+    secret?: string;
+    insecure_ssl?: '0' | '1';
+
+  }
+}

--- a/functions/src/repository/create-git-webhook-repository.ts
+++ b/functions/src/repository/create-git-webhook-repository.ts
@@ -52,7 +52,6 @@ export async function getWebhook(repositoryUid: string, token: string): Promise<
 
   if (exist) {
     return GitHubRepositoryWebhookMapper.import(exist);
-  } else {
-    return GitHubRepositoryWebhookMapper.import(await createWebhook(repositoryUid, token));
   }
+  return GitHubRepositoryWebhookMapper.import(await createWebhook(repositoryUid, token));
 }

--- a/functions/src/repository/create-git-webhook-repository.ts
+++ b/functions/src/repository/create-git-webhook-repository.ts
@@ -1,0 +1,47 @@
+// Third party modules
+import { firestore } from 'firebase-admin';
+
+import { enviroment } from '../environments/environment';
+import { GitHubRepositoryWebhookRequestCreate, GitHubRepositoryWebhookResponse } from '../mappers/github/webhook.mapper';
+import { DocumentData, DocumentReference, FirebaseAdmin } from './../client/firebase-admin';
+import { GitHubClientPost } from './../client/github';
+import { Logger } from './../client/logger';
+
+export interface CreateGitWebhookRepositoryInput {
+  token: string;
+  repositoryUid: string;
+}
+
+export const onCreateGitWebhookRepository: any = async (token: string, repositoryUid: string) => {
+  try {
+    const repositorySnapshot: DocumentReference = FirebaseAdmin.firestore().collection('repositories').doc(repositoryUid) 
+    const repository: DocumentData = (await FirebaseAdmin.firestore().collection('repositories').doc(repositoryUid).get()).data();
+
+    repository.webhook = await createWebhook(repository, token);
+    await repositorySnapshot.update(repository);
+
+    return repository;
+  } catch (error) {
+    Logger.error(error);
+    throw new Error(error);
+  }
+};
+
+
+function createWebhook(repository: DocumentData, token: string): Promise<GitHubRepositoryWebhookResponse> {
+  const body: GitHubRepositoryWebhookRequestCreate = {
+    // name: enviroment.githubWebhook.name,
+    name: 'web',
+    active: true,
+    events: [
+      'push',
+      'pull_request',
+    ],
+    config: {
+      url: enviroment.githubWebhook.url,
+      content_type: 'json',
+      insecure_ssl: '0',
+    },
+  }
+  return GitHubClientPost<GitHubRepositoryWebhookResponse>(`/repos/${repository.fullName}/hooks`, token, body);
+}

--- a/functions/src/repository/create-git-webhook-repository.ts
+++ b/functions/src/repository/create-git-webhook-repository.ts
@@ -15,18 +15,12 @@ export const onCreateGitWebhookRepository: any = async (token: string, repositor
     const repositorySnapshot: DocumentReference = FirebaseAdmin.firestore().collection('repositories').doc(repositoryUid);
     const repository: DocumentData = (await repositorySnapshot.get()).data();
 
-    let webhook: GitHubRepositoryWebhookModel;
-
-    const exist: GitHubRepositoryWebhookResponse = await findWebhook(repository, token);
-
-    if (exist) {
-      webhook = GitHubRepositoryWebhookMapper.import(exist);
-    } else {
-      webhook = GitHubRepositoryWebhookMapper.import(await createWebhook(repository, token));
-    }
+    const webhook: GitHubRepositoryWebhookModel = await getWebhook(repository.fullName, token);
 
     repository.webhook = webhook;
     await repositorySnapshot.update(repository);
+
+    Logger.info({ webhook });
 
     return repository;
   } catch (error) {
@@ -36,7 +30,7 @@ export const onCreateGitWebhookRepository: any = async (token: string, repositor
 };
 
 
-export function createWebhook(repository: DocumentData, token: string): Promise<GitHubRepositoryWebhookResponse> {
+export function createWebhook(repositoryUid: string, token: string): Promise<GitHubRepositoryWebhookResponse> {
   const body: GitHubRepositoryWebhookRequestCreate = {
     // name: enviroment.githubWebhook.name,
     name: 'web',
@@ -48,5 +42,17 @@ export function createWebhook(repository: DocumentData, token: string): Promise<
       insecure_ssl: '0',
     },
   }
-  return GitHubClientPost<GitHubRepositoryWebhookResponse>(`/repos/${repository.fullName}/hooks`, token, body);
+  return GitHubClientPost<GitHubRepositoryWebhookResponse>(`/repos/${repositoryUid}/hooks`, token, body);
+}
+
+
+export async function getWebhook(repositoryUid: string, token: string): Promise<GitHubRepositoryWebhookModel> {
+
+  const exist: GitHubRepositoryWebhookResponse = await findWebhook(repositoryUid, token);
+
+  if (exist) {
+    return GitHubRepositoryWebhookMapper.import(exist);
+  } else {
+    return GitHubRepositoryWebhookMapper.import(await createWebhook(repositoryUid, token));
+  }
 }

--- a/functions/src/repository/create-repository.ts
+++ b/functions/src/repository/create-repository.ts
@@ -4,32 +4,36 @@ import { firestore, CloudFunction, EventContext } from 'firebase-functions';
 // Dashboard hub firebase functions models/mappers
 import { DocumentData, DocumentSnapshot, FirebaseAdmin, QueryDocumentSnapshot } from './../client/firebase-admin';
 
+async function addProjects(repositoryUid: string, repo: DocumentData): Promise<boolean> {
+  const projects: QueryDocumentSnapshot[] = (await FirebaseAdmin.firestore().collection('projects').where('repositories', 'array-contains', repositoryUid).get()).docs;
+
+  if (!Array.isArray(repo.projects)) {
+    repo.projects = [];
+  }
+
+  for (const project of projects) {
+    repo.projects.push(project.id);
+  }
+
+  if (projects.length > 0) {
+    return true;
+  }
+
+  return false;
+}
+
 export const onCreateRepository: CloudFunction<DocumentSnapshot> = firestore
   .document('repositories/{repositoryUid}')
   .onCreate(async (repositorySnapshot: DocumentSnapshot, context: EventContext) => {
-
     try {
       const newData: DocumentData = repositorySnapshot.data();
-
-      const projects: QueryDocumentSnapshot[] = (await FirebaseAdmin.firestore().collection('projects').where('repositories', 'array-contains', context.params.repositoryUid).get()).docs;
-
-      if (!Array.isArray(newData.projects)) {
-        newData.projects = [];
-      }
-
-      for (const project of projects) {
-        newData.projects.push(project.id);
-      }
-
-      if (projects.length > 0) {
+      const isNeedUpdate: boolean = await addProjects(context.params.repositoryUid, newData);
+      if (isNeedUpdate) {
         return repositorySnapshot.ref.update(newData);
       }
-
       return newData;
-
     } catch (err) {
       console.log(err)
       throw err;
     }
-
   });

--- a/functions/src/repository/delete-git-webhook-repository.ts
+++ b/functions/src/repository/delete-git-webhook-repository.ts
@@ -1,0 +1,31 @@
+import { DocumentData, DocumentReference, FirebaseAdmin } from './../client/firebase-admin';
+import { GitHubClientDelete } from './../client/github';
+import { Logger } from './../client/logger';
+
+export interface DeleteGitWebhookRepositoryInput {
+  token: string;
+  repositoryUid: string;
+}
+
+export const onDeleteGitWebhookRepository: any = async (token: string, repositoryUid: string) => {
+  try {
+    const repositorySnapshot: DocumentReference = FirebaseAdmin.firestore().collection('repositories').doc(repositoryUid);
+    const repository: DocumentData = (await repositorySnapshot.get()).data();
+
+    if (repository.webhook) {
+      await deleteWebhook(repository, token);
+      repository.webhook = null;
+      await repositorySnapshot.update(repository);
+    }
+
+    return repository;
+  } catch (error) {
+    Logger.error(error);
+    throw new Error(error);
+  }
+};
+
+
+function deleteWebhook(repository: DocumentData, token: string): Promise<void> {
+  return GitHubClientDelete<void>(`/repos/${repository.fullName}/hooks/${repository.webhook.id}`, token);
+}

--- a/functions/src/repository/delete-git-webhook-repository.ts
+++ b/functions/src/repository/delete-git-webhook-repository.ts
@@ -12,7 +12,7 @@ export const onDeleteGitWebhookRepository: any = async (token: string, repositor
     const repositorySnapshot: DocumentReference = FirebaseAdmin.firestore().collection('repositories').doc(repositoryUid);
     const repository: DocumentData = (await repositorySnapshot.get()).data();
 
-    if (repository.webhook) {
+    if (repository.projects && repository.projects.length === 1 && repository.webhook) {
       await deleteWebhook(repository, token);
       repository.webhook = null;
       await repositorySnapshot.update(repository);

--- a/functions/src/repository/find-git-webhook-repository.ts
+++ b/functions/src/repository/find-git-webhook-repository.ts
@@ -1,26 +1,6 @@
-import { CallableContext } from 'firebase-functions/lib/providers/https';
 import { enviroment } from '../environments/environment';
 import { GitHubRepositoryWebhookResponse } from '../mappers/github/webhook.mapper';
-import { DocumentData, DocumentReference, FirebaseAdmin } from './../client/firebase-admin';
 import { GitHubClient } from './../client/github';
-import { Logger } from './../client/logger';
-
-export interface FindGitWebhookRepositoryInput {
-  token: string;
-  repositoryUid: string;
-}
-
-export const onFindGitWebhookRepository: any = async (token: string, repositoryUid: string) => {
-  try {
-    const repositorySnapshot: DocumentReference = FirebaseAdmin.firestore().collection('repositories').doc(repositoryUid);
-    const repository: DocumentData = (await repositorySnapshot.get()).data();
-
-    return await findWebhook(repository.fullName, token);
-  } catch (error) {
-    Logger.error(error);
-    throw new Error(error);
-  }
-};
 
 
 export function listWebhook(repositoryUid: string, token: string): Promise<GitHubRepositoryWebhookResponse[]> {

--- a/functions/src/repository/find-git-webhook-repository.ts
+++ b/functions/src/repository/find-git-webhook-repository.ts
@@ -1,0 +1,36 @@
+import { CallableContext } from 'firebase-functions/lib/providers/https';
+import { enviroment } from '../environments/environment';
+import { GitHubRepositoryWebhookResponse } from '../mappers/github/webhook.mapper';
+import { DocumentData, DocumentReference, FirebaseAdmin } from './../client/firebase-admin';
+import { GitHubClient } from './../client/github';
+import { Logger } from './../client/logger';
+
+export interface FindGitWebhookRepositoryInput {
+  token: string;
+  repositoryUid: string;
+}
+
+export const onFindGitWebhookRepository: any = async (token: string, repositoryUid: string) => {
+  try {
+    const repositorySnapshot: DocumentReference = FirebaseAdmin.firestore().collection('repositories').doc(repositoryUid);
+    const repository: DocumentData = (await repositorySnapshot.get()).data();
+
+    return await findWebhook(repository, token);
+  } catch (error) {
+    Logger.error(error);
+    throw new Error(error);
+  }
+};
+
+
+export function listWebhook(repository: DocumentData, token: string): Promise<GitHubRepositoryWebhookResponse[]> {
+  return GitHubClient<GitHubRepositoryWebhookResponse[]>(`/repos/${repository.fullName}/hooks`, token);
+}
+
+
+export async function findWebhook(repository: DocumentData, token: string): Promise<GitHubRepositoryWebhookResponse> {
+
+  const list: GitHubRepositoryWebhookResponse[] = await listWebhook(repository, token);
+
+  return list.find((elem: GitHubRepositoryWebhookResponse) => elem.config.url === enviroment.githubWebhook.url)
+}

--- a/functions/src/repository/find-git-webhook-repository.ts
+++ b/functions/src/repository/find-git-webhook-repository.ts
@@ -15,7 +15,7 @@ export const onFindGitWebhookRepository: any = async (token: string, repositoryU
     const repositorySnapshot: DocumentReference = FirebaseAdmin.firestore().collection('repositories').doc(repositoryUid);
     const repository: DocumentData = (await repositorySnapshot.get()).data();
 
-    return await findWebhook(repository, token);
+    return await findWebhook(repository.fullName, token);
   } catch (error) {
     Logger.error(error);
     throw new Error(error);
@@ -23,14 +23,13 @@ export const onFindGitWebhookRepository: any = async (token: string, repositoryU
 };
 
 
-export function listWebhook(repository: DocumentData, token: string): Promise<GitHubRepositoryWebhookResponse[]> {
-  return GitHubClient<GitHubRepositoryWebhookResponse[]>(`/repos/${repository.fullName}/hooks`, token);
+export function listWebhook(repositoryUid: string, token: string): Promise<GitHubRepositoryWebhookResponse[]> {
+  return GitHubClient<GitHubRepositoryWebhookResponse[]>(`/repos/${repositoryUid}/hooks`, token);
 }
 
 
-export async function findWebhook(repository: DocumentData, token: string): Promise<GitHubRepositoryWebhookResponse> {
+export async function findWebhook(repositoryUid: string, token: string): Promise<GitHubRepositoryWebhookResponse> {
+  const list: GitHubRepositoryWebhookResponse[] = await listWebhook(repositoryUid, token);
 
-  const list: GitHubRepositoryWebhookResponse[] = await listWebhook(repository, token);
-
-  return list.find((elem: GitHubRepositoryWebhookResponse) => elem.config.url === enviroment.githubWebhook.url)
+  return list.find((elem: GitHubRepositoryWebhookResponse) => elem && elem.config && elem.config.url === enviroment.githubWebhook.url)
 }

--- a/functions/src/repository/response-git-webhook-repository.ts
+++ b/functions/src/repository/response-git-webhook-repository.ts
@@ -1,10 +1,11 @@
 // Third party modules
 import * as CORS from 'cors';
-import { RequestHandler, Response } from 'express';
 // import { firestore } from 'firebase-admin';
-import { https, HttpsFunction } from 'firebase-functions';
+import { https, HttpsFunction, Response } from 'firebase-functions';
+import { Logger } from '../client/logger';
 
-const cors: RequestHandler = CORS({
+// tslint:disable-next-line: typedef
+const cors = CORS({
   origin: true,
 });
 
@@ -15,7 +16,7 @@ export interface ResponseGitWebhookRepositoryInput {
 
 export const onResponseGitWebhookRepository: HttpsFunction = https.onRequest((req: https.Request, res: Response) => {
   return cors(req, res, () => {
-    console.log(`${req.protocol}://${req.hostname} ; onResponseGitWebhookRepository: success!`);
+    Logger.info(`${req.protocol}://${req.hostname} ; onResponseGitWebhookRepository: success!`);
     res.status(200).send();
   });
 });

--- a/functions/src/repository/response-git-webhook-repository.ts
+++ b/functions/src/repository/response-git-webhook-repository.ts
@@ -1,0 +1,21 @@
+// Third party modules
+import * as CORS from 'cors';
+import { RequestHandler, Response } from 'express';
+// import { firestore } from 'firebase-admin';
+import { https, HttpsFunction } from 'firebase-functions';
+
+const cors: RequestHandler = CORS({
+  origin: true,
+});
+
+export interface ResponseGitWebhookRepositoryInput {
+  token: string;
+  repositoryUid: string;
+}
+
+export const onResponseGitWebhookRepository: HttpsFunction = https.onRequest((req: https.Request, res: Response) => {
+  return cors(req, res, () => {
+    console.log(`${req.protocol}://${req.hostname} ; onResponseGitWebhookRepository: success!`);
+    res.status(200).send();
+  });
+});

--- a/functions/src/repository/update-repository.ts
+++ b/functions/src/repository/update-repository.ts
@@ -4,7 +4,7 @@ import { firestore, Change, CloudFunction, EventContext } from 'firebase-functio
 // Dashboard hub firebase functions models/mappers
 import { DocumentData, DocumentSnapshot, FirebaseAdmin } from './../client/firebase-admin';
 
-export const onUpdateDeleteRepository: CloudFunction<Change<DocumentSnapshot>> = firestore
+export const onUpdateRepository: CloudFunction<Change<DocumentSnapshot>> = firestore
   .document('repositories/{repositoryUid}')
   .onUpdate((change: Change<DocumentSnapshot>, context: EventContext) => {
 

--- a/web/src/app/core/services/project.service.ts
+++ b/web/src/app/core/services/project.service.ts
@@ -6,7 +6,7 @@ import { map, mergeMap, switchMap, take, tap } from 'rxjs/operators';
 import { v4 as uuid } from 'uuid';
 
 // Dashboard model and services
-import { IProject, RepositoryModel } from '../../shared/models/index.model';
+import { IProject, ProjectModel, RepositoryModel } from '../../shared/models/index.model';
 import { ActivityService } from './activity.service';
 import { AuthenticationService } from './authentication.service';
 import { RepositoryService } from './repository.service';
@@ -145,7 +145,7 @@ export class ProjectService {
         .pipe(
           switchMap(() => this.afs
             .collection<IProject>('projects')
-            .doc<IProject>(uid)
+            .doc<IProject>(project.uid)
             .set(
               {
                 repositories: [],
@@ -162,7 +162,7 @@ export class ProjectService {
         mergeMap(() => forkJoin(...repositories.map((repository: string) => this.repositoryService.loadRepository(repository)))),
         switchMap(() => this.afs
           .collection<IProject>('projects')
-          .doc<IProject>(uid)
+          .doc<IProject>(project.uid)
           .set(
             {
               repositories: repositories.map((repoUid: string) => new RepositoryModel(repoUid).uid),

--- a/web/src/app/core/services/repository.service.ts
+++ b/web/src/app/core/services/repository.service.ts
@@ -25,8 +25,8 @@ export class RepositoryService {
 
   // Forces refresh of users repositories
   public refresh(): Observable<RepositoriesModel> {
-      const callable: any = this.fns.httpsCallable('findAllUserRepositories');
-      return callable({ token: this.authService.profile.oauth.githubToken });
+    const callable: any = this.fns.httpsCallable('findAllUserRepositories');
+    return callable({ token: this.authService.profile.oauth.githubToken });
   }
 
   // This function returns the repository via uid
@@ -42,5 +42,10 @@ export class RepositoryService {
   public loadRepository(fullName: string): Observable<boolean> {
     const callable: any = this.fns.httpsCallable('findRepositoryInfo');
     return callable({ fullName, token: this.authService.profile.oauth.githubToken });
+  }
+
+  public createGitWebhook(repo: RepositoryModel): Observable<RepositoryModel> {
+    const callable: any = this.fns.httpsCallable('createGitWebhookRepository');
+    return callable({ repositoryUid: repo.uid, token: this.authService.profile.oauth.githubToken });
   }
 }

--- a/web/src/app/core/services/repository.service.ts
+++ b/web/src/app/core/services/repository.service.ts
@@ -48,4 +48,9 @@ export class RepositoryService {
     const callable: any = this.fns.httpsCallable('createGitWebhookRepository');
     return callable({ repositoryUid: repo.uid, token: this.authService.profile.oauth.githubToken });
   }
+
+  public deleteGitWebhook(repositoryUid: string): Observable<RepositoryModel> {
+    const callable: any = this.fns.httpsCallable('deleteGitWebhookRepository');
+    return callable({ repositoryUid, token: this.authService.profile.oauth.githubToken });
+  }
 }

--- a/web/src/app/projects/repository/repository.component.html
+++ b/web/src/app/projects/repository/repository.component.html
@@ -9,6 +9,17 @@
   </mat-card-header>
   <mat-divider></mat-divider>
   <mat-card-content>
+
+    <div *ngIf="repository.webhook == null || repository.webhook.id == null" fxLayout="row" fxLayoutGap="20px" fxLayoutAlign="center" class="alert-row">
+      <div fxFlex="100%" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="20px" class="alert alert-danger">
+        <mat-icon class="icon">warning</mat-icon>
+        <span class="message"> Not found webhook on this repository!</span>
+        <button class="btn-action" mat-stroked-button (click)="createWebhook()">
+          Create webhook!
+        </button>
+      </div>
+    </div>
+
     <div fxLayout="row" fxLayoutGap="2%" class="dashboard-cards-row">
       <div fxFlex="24%">
         <mat-card>
@@ -116,7 +127,7 @@
                 <mat-icon class="person-class">person</mat-icon>
               </div>
               <div fxFlex="85%">
-                <p class="bottom-line" mat-line *ngIf="repository.pullRequests && repository.pullRequests.length > 0">  {{repository.pullRequests[0].title}} </p>
+                <p class="bottom-line" mat-line *ngIf="repository.pullRequests && repository.pullRequests.length > 0"> {{repository.pullRequests[0].title}} </p>
                 <p class="bottom-line-none" *ngIf="repository.pullRequests && !repository.pullRequests.length" mat-line>Title: N/A</p>
               </div>
             </div>

--- a/web/src/app/projects/repository/repository.component.scss
+++ b/web/src/app/projects/repository/repository.component.scss
@@ -102,3 +102,38 @@ mat-list {
     height: 60px;
   }
 }
+.alert-row {
+  margin-top: 10px;
+
+  .alert {
+    min-width: 150px;
+    padding: 10px 15px;
+    margin: 10px;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    box-shadow: 0 1px 3px rgba(#000, .12), 0 1px 2px rgba(#000, .24);
+
+    &:hover {
+      box-shadow: 0 3px 6px rgba(#000, .16), 0 3px 6px rgba(#000, .23);
+    }
+
+    &-success {
+      background-color: lighten(#5cb85c, 15%);
+      border-color: lighten(#5cb85c, 10%);
+      color: darken(#5cb85c, 15%);
+    }
+
+    &-warning {
+      background-color: lighten(#E2A41F, 15%);
+      border-color: lighten(#E2A41F, 10%);
+      color: darken(#E2A41F, 15%);
+    }
+
+    &-danger {
+      background-color: lighten(#e53935, 10%);
+      border-color: lighten(#e53935, 5%);
+      color: white;
+    }
+  }
+
+}

--- a/web/src/app/projects/repository/repository.component.ts
+++ b/web/src/app/projects/repository/repository.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 // Dashboard hub model and services
 import { RepositoryService, SortingService } from '../../core/services/index.service';
@@ -48,5 +49,13 @@ export class RepositoryComponent implements OnInit {
   ngDestroy(): void {
     this.repositorySubscription
       .unsubscribe();
+  }
+
+  public createWebhook(): void {
+    this.repositoryService.createGitWebhook(this.repository)
+      .pipe(take(1))
+      .subscribe((data: RepositoryModel) => {
+        console.log(data);
+      });
   }
 }

--- a/web/src/app/projects/repository/repository.component.ts
+++ b/web/src/app/projects/repository/repository.component.ts
@@ -54,8 +54,6 @@ export class RepositoryComponent implements OnInit {
   public createWebhook(): void {
     this.repositoryService.createGitWebhook(this.repository)
       .pipe(take(1))
-      .subscribe((data: RepositoryModel) => {
-        console.log(data);
-      });
+      .subscribe();
   }
 }

--- a/web/src/app/projects/view/view.component.ts
+++ b/web/src/app/projects/view/view.component.ts
@@ -49,7 +49,7 @@ export class ViewProjectComponent implements OnInit {
       .pipe(
         filter((selectedRepositories: { value: string }[]) => !!selectedRepositories),
         switchMap((selectedRepositories: { value: string }[]) => this.projectService.saveRepositories(
-          this.project.uid,
+          this.project,
           selectedRepositories.map((fullName: { value: string }) => fullName.value)
         ))
       )

--- a/web/src/app/shared/models/repository.model.ts
+++ b/web/src/app/shared/models/repository.model.ts
@@ -37,6 +37,10 @@ export class RepositoryModel {
 
   constructor(fullName: string) {
     this.fullName = fullName;
-    this.uid = fullName.replace('/', '+');
+    this.uid = RepositoryModel.getUid(fullName);
+  }
+
+  public static getUid(fullName: string): string {
+    return fullName.replace('/', '+');
   }
 }

--- a/web/src/app/shared/models/repository.model.ts
+++ b/web/src/app/shared/models/repository.model.ts
@@ -3,6 +3,7 @@ import { IssueModel } from './issue.model';
 import { MilestoneModel } from './milestone.model';
 import { PullRequestModel } from './pullRequest.model';
 import { ReleaseModel } from './release.model';
+import { WebhookModel } from './webhook.model';
 
 /**
  * Repository model
@@ -32,6 +33,7 @@ export class RepositoryModel {
   lastUpdated: Date;
   contributors: ContributorModel[];
   milestones: MilestoneModel[];
+  webhook: WebhookModel;
 
   constructor(fullName: string) {
     this.fullName = fullName;

--- a/web/src/app/shared/models/webhook.model.ts
+++ b/web/src/app/shared/models/webhook.model.ts
@@ -1,0 +1,23 @@
+export class WebhookModel {
+  type: string;
+  id: number;
+  name: string;
+  active: boolean;
+  events: string[];
+  config: {
+    url: string;
+    contentType?: 'form' | 'json';
+    secret?: string;
+    insecureSsl?: '0' | '1';
+  };
+  updatedAt: Date;
+  createdAt: Date;
+  url: string;
+  testUrl: string;
+  pingUrl: string;
+  lastResponse: {
+    code?: any;
+    status: string;
+    message?: any;
+  };
+}


### PR DESCRIPTION
Done:

- alert if there is no webhook on repo was added;
- function for webhook creation using http query was added.

Problems:

- I can't assign a name to webhook
- problem w/ auto removing: I can't get user info from event into trigger (https://stackoverflow.com/questions/46912161/getting-the-user-id-from-a-firestore-trigger-in-cloud-functions-for-firebase). Possible solution: create a cloud function instead of trigger for this.