### PR TITLE
feat(monitors): #1388 added tooltip and guard to protect route

### DIFF
--- a/web/src/app/monitors/monitors-list/monitors-list.component.html
+++ b/web/src/app/monitors/monitors-list/monitors-list.component.html
@@ -10,8 +10,8 @@
       <mat-card-title>Monitors</mat-card-title>
       <mat-card-subtitle>You have {{ monitors.length }} monitors</mat-card-subtitle>
       <span fxFlex></span>
-      <span fxLayout="row" fxLayoutGap="20px" fxLayoutAlign="center center">
-        <button mat-raised-button type="submit" color="accent" routerLink="create">
+      <span fxLayout="row" fxLayoutGap="20px" fxLayoutAlign="center center" matTooltip="Monitors reach of limit 3" matTooltipPosition="above" [matTooltipDisabled]="monitors.length < 3">
+        <button mat-raised-button type="submit" color="accent" routerLink="create" [disabled]="monitors.length >= 3">
           <mat-icon>add</mat-icon> Monitor
         </button>
       </span>
@@ -22,7 +22,7 @@
           <div class="monitors">
             <h4 mat-line><a [routerLink]="[monitor.uid,'pings']">{{monitor.name}}</a></h4>
             <p mat-line>{{monitor.method}} {{monitor.path}} {{monitor.expectedCode}} {{monitor.expectedText}}</p>
-            <p mat-line>Successful pings: {{monitor.successfulPings || 0}} | Unsuccessful pings: {{monitor.unsuccessfulPings || 0}}  </p>
+            <p mat-line>Successful pings: {{monitor.successfulPings || 0}} | Unsuccessful pings: {{monitor.unsuccessfulPings || 0}} </p>
             <p mat-line></p>
           </div>
           <div class="pings" fxLayout="column" *ngIf="monitor.latestPing">

--- a/web/src/app/projects/projects-routing.module.ts
+++ b/web/src/app/projects/projects-routing.module.ts
@@ -36,6 +36,7 @@ const routes: Routes = [
   {
     path: ':projectUid/monitors',
     loadChildren: '../monitors/monitors.module#MonitorsModule',
+    canActivate: [AuthGuard],
   },
   {
     path: ':projectUid/tokens',

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -96,5 +96,5 @@ mat-progress-bar {
 }
 
 .mat-tooltip{
-  font-size: 0.75rem !important;
+  font-size: 0.75rem;
 }

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -94,3 +94,7 @@ mat-progress-bar {
   margin-bottom: 10px;
   border: red 1px solid;
 }
+
+.mat-tooltip{
+  font-size: 0.75rem !important;
+}


### PR DESCRIPTION
closes #1388 

### Notes

A summary of what was achieved in this PR

- [ ] Disabled add monitor button if more than 3 monitors
- [ ] Added tooltip if monitors more than 3
- [ ] Added guard for protecting monitors route