### PR TITLE
feat(main): #1518 make users and popular projects count same on homepage

### DIFF
--- a/web/src/app/core/services/project.service.ts
+++ b/web/src/app/core/services/project.service.ts
@@ -175,8 +175,10 @@ export class ProjectService {
         switchMap(() => this.afs
           .collection<IProject>(
             'projects',
-            (ref: firebase.firestore.Query) => ref.where('type', '==', 'public')
-              .orderBy('views', 'desc').limit(4)
+            (ref: firebase.firestore.Query) => ref
+              .where('type', '==', 'public')
+              .orderBy('views', 'desc')
+              .limit(4)
           )
           .valueChanges()),
         map((projects: IProject[]) => projects.map((project: IProject) => new ProjectModel(project)))

--- a/web/src/app/core/services/project.service.ts
+++ b/web/src/app/core/services/project.service.ts
@@ -176,7 +176,7 @@ export class ProjectService {
           .collection<IProject>(
             'projects',
             (ref: firebase.firestore.Query) => ref.where('type', '==', 'public')
-              .orderBy('views', 'desc').limit(3)
+              .orderBy('views', 'desc').limit(4)
           )
           .valueChanges()),
         map((projects: IProject[]) => projects.map((project: IProject) => new ProjectModel(project)))

--- a/web/src/app/core/services/user.service.ts
+++ b/web/src/app/core/services/user.service.ts
@@ -28,8 +28,9 @@ export class UserService {
         switchMap(() => this.afs
           .collection<UserStatsModel>(
             'userStats',
-            (ref: firebase.firestore.Query) => ref.orderBy('lastUpdated', 'desc')
-            .limit(4)
+            (ref: firebase.firestore.Query) => ref
+              .orderBy('lastUpdated', 'desc')
+              .limit(4)
           )
           .valueChanges())
       );

--- a/web/src/app/core/services/user.service.ts
+++ b/web/src/app/core/services/user.service.ts
@@ -29,6 +29,7 @@ export class UserService {
           .collection<UserStatsModel>(
             'userStats',
             (ref: firebase.firestore.Query) => ref.orderBy('lastUpdated', 'desc')
+            .limit(4)
           )
           .valueChanges())
       );


### PR DESCRIPTION
closes #1518 

### Notes

A summary of what was achieved in this PR

- [ ] Set the limit 4 for active users and popular projects on homepage