### PR TITLE
feat(monitors): #1519 remove the update of updateOn from project while ping

### DIFF
--- a/functions/src/monitor/monitor.ts
+++ b/functions/src/monitor/monitor.ts
@@ -76,7 +76,6 @@ export const ping: any = async (projectUid: string, monitorUid: string, type: Pi
     .set(
       {
         monitors: project.monitors,
-        updatedOn: new Date(),
       },
       { merge: true });
 


### PR DESCRIPTION
closes #1519 

### Notes

A summary of what was achieved in this PR

- [ ] Removed the udpate of field `updatedOn` from projects while ping monitor