### PR TITLE
feat(project): #627 added support for updating og tags via meta service

### DIFF
--- a/web/src/app/projects/view/view.component.ts
+++ b/web/src/app/projects/view/view.component.ts
@@ -79,7 +79,7 @@ export class ViewProjectComponent implements OnInit, OnDestroy {
     this.meta.updateTag({ property: 'og:title', content: this.project.title });
     this.meta.updateTag({
       property: 'og:image', content: this.project.logoUrl
-        ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png',
+        ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/logo-horizontal-std-2567x580.png',
     });
   }
 

--- a/web/src/app/projects/view/view.component.ts
+++ b/web/src/app/projects/view/view.component.ts
@@ -76,8 +76,8 @@ export class ViewProjectComponent implements OnInit, OnDestroy {
    * Update meta tags for title and image for SEO
    */
   updateMetaTags(): void {
-    this.meta.updateTag({ 'og:title': this.project.title });
-    this.meta.updateTag({ 'og:image': this.project.logoUrl ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/favicon.ico' });
+    this.meta.updateTag({name: 'og:title', content: this.project.title});
+    this.meta.updateTag({ name: 'og:image', content: this.project.logoUrl ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/favicon.ico' });
   }
 
   /**

--- a/web/src/app/projects/view/view.component.ts
+++ b/web/src/app/projects/view/view.component.ts
@@ -76,10 +76,10 @@ export class ViewProjectComponent implements OnInit, OnDestroy {
    * Update meta tags for title and image for SEO
    */
   updateMetaTags(): void {
-    this.meta.updateTag({ property: "og:title", content: this.project.title });
+    this.meta.updateTag({ property: 'og:title', content: this.project.title });
     this.meta.updateTag({
-      property: "og:image", content: this.project.logoUrl
-        ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/logo-horizontal-std-2567x580.png',
+      property: 'og:image', content: this.project.logoUrl
+        ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png',
     });
   }
 

--- a/web/src/app/projects/view/view.component.ts
+++ b/web/src/app/projects/view/view.component.ts
@@ -1,6 +1,7 @@
 // Core modules
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material';
+import { Meta } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 
 // Thid party modules
@@ -43,7 +44,8 @@ export class ViewProjectComponent implements OnInit, OnDestroy {
     private router: Router,
     private dialog: MatDialog,
     private projectService: ProjectService,
-    private authService: AuthenticationService
+    private authService: AuthenticationService,
+    private meta: Meta
   ) {
     this.route.data.subscribe((data: { project: ProjectModel }) => this.project = data.project);
   }
@@ -66,6 +68,16 @@ export class ViewProjectComponent implements OnInit, OnDestroy {
         }
       }
       );
+
+    this.updateMetaTags();
+  }
+
+  /**
+   * Update meta tags for title and image for SEO
+   */
+  updateMetaTags(): void {
+    this.meta.updateTag({ 'og:title': this.project.title });
+    this.meta.updateTag({ 'og:image': this.project.logoUrl ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/favicon.ico' });
   }
 
   /**

--- a/web/src/app/projects/view/view.component.ts
+++ b/web/src/app/projects/view/view.component.ts
@@ -76,10 +76,10 @@ export class ViewProjectComponent implements OnInit, OnDestroy {
    * Update meta tags for title and image for SEO
    */
   updateMetaTags(): void {
-    this.meta.updateTag({ property: 'og:title', content: this.project.title });
+    this.meta.updateTag({ property: "og:title", content: this.project.title });
     this.meta.updateTag({
-      property: 'og:image', content: this.project.logoUrl
-        ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/favicon.ico',
+      property: "og:image", content: this.project.logoUrl
+        ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/logo-horizontal-std-2567x580.png',
     });
   }
 

--- a/web/src/app/projects/view/view.component.ts
+++ b/web/src/app/projects/view/view.component.ts
@@ -79,7 +79,7 @@ export class ViewProjectComponent implements OnInit, OnDestroy {
     this.meta.updateTag({ property: 'og:title', content: this.project.title });
     this.meta.updateTag({
       property: 'og:image', content: this.project.logoUrl
-        ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/logo-horizontal-std-2567x580.png',
+        ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png',
     });
   }
 

--- a/web/src/app/projects/view/view.component.ts
+++ b/web/src/app/projects/view/view.component.ts
@@ -76,8 +76,8 @@ export class ViewProjectComponent implements OnInit, OnDestroy {
    * Update meta tags for title and image for SEO
    */
   updateMetaTags(): void {
-    this.meta.addTag({ property: 'og:title', content: this.project.title });
-    this.meta.addTag({
+    this.meta.updateTag({ property: 'og:title', content: this.project.title });
+    this.meta.updateTag({
       property: 'og:image', content: this.project.logoUrl
         ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/favicon.ico',
     });

--- a/web/src/app/projects/view/view.component.ts
+++ b/web/src/app/projects/view/view.component.ts
@@ -76,8 +76,11 @@ export class ViewProjectComponent implements OnInit, OnDestroy {
    * Update meta tags for title and image for SEO
    */
   updateMetaTags(): void {
-    this.meta.updateTag({name: 'og:title', content: this.project.title});
-    this.meta.updateTag({ name: 'og:image', content: this.project.logoUrl ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/favicon.ico' });
+    this.meta.updateTag({ property: 'og:title', content: this.project.title });
+    this.meta.updateTag({
+      property: 'og:image', content: this.project.logoUrl
+        ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/favicon.ico',
+    });
   }
 
   /**

--- a/web/src/app/projects/view/view.component.ts
+++ b/web/src/app/projects/view/view.component.ts
@@ -76,8 +76,8 @@ export class ViewProjectComponent implements OnInit, OnDestroy {
    * Update meta tags for title and image for SEO
    */
   updateMetaTags(): void {
-    this.meta.updateTag({ property: 'og:title', content: this.project.title });
-    this.meta.updateTag({
+    this.meta.addTag({ property: 'og:title', content: this.project.title });
+    this.meta.addTag({
       property: 'og:image', content: this.project.logoUrl
         ? this.project.logoUrl : 'https://cdn.dashboardhub.io/logo/favicon.ico',
     });

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -10,7 +10,7 @@
   <meta name="application-name" content="DashboardHub PipelineDashboard">
   <meta name="theme-color" content="#1976d2">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/logo-horizontal-std.svg">
+  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/logo-horizontal-std-2567x580.png">
   <meta property="og:title" content="PipelineDashboard">
 
 

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -10,10 +10,18 @@
   <meta name="application-name" content="DashboardHub PipelineDashboard">
   <meta name="theme-color" content="#1976d2">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+ <!-- Facbook meta tags -->
+  <meta property="og:title" content="DashboardHub">
   <meta property="og:image" content="https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png">
-  <meta property="og:image:width" content="400" />
-  <meta property="og:image:height" content="300" />
-  <meta property="og:title" content="PipelineDashboard">
+  <meta property="og:image:width" content="200">
+  <meta property="og:image:height" content="200">
+
+  <!-- Twitter meta tags -->
+  <meta property="twitter:title" content="DashboardHub">
+  <meta property="twitter:image:src" content="https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png">
+  <meta property="twitter:image:width" content="200">
+  <meta property="twitter:image:height" content="200">
 
 
   <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -13,14 +13,15 @@
 
   <!-- Facbook meta tags -->
   <meta property="og:title" content="DashboardHub">
-  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/logo-horizontal-std-2567x580.png">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png">
 
   <!-- Twitter meta tags -->
   <meta property="twitter:site" content="DashboardHub">
   <meta property="twitter:creator" content="DashboardHub">
-  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:card" content="summary">
   <meta property="twitter:title" content="DashboardHub">
-  <meta property="twitter:image:src" content="https://cdn.dashboardhub.io/logo/logo-horizontal-std-2567x580.png">
+  <meta property="twitter:image:src" content="https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png">
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -13,18 +13,14 @@
 
   <!-- Facbook meta tags -->
   <meta property="og:title" content="DashboardHub">
-  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png">
-  <meta property="og:image:width" content="200">
-  <meta property="og:image:height" content="200">
+  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/icon-only-orange-120x120.png">
 
   <!-- Twitter meta tags -->
   <meta property="twitter:site" content="DashboardHub">
   <meta property="twitter:creator" content="DashboardHub">
-  <meta property="twitter:card" content="DashboardHubLogo">
+  <meta property="twitter:card" content="summary_large_image">
   <meta property="twitter:title" content="DashboardHub">
-  <meta property="twitter:image:src" content="https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png">
-  <meta property="twitter:image:width" content="200">
-  <meta property="twitter:image:height" content="200">
+  <meta property="twitter:image:src" content="https://cdn.dashboardhub.io/logo/icon-only-orange-120x120.png">
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -10,6 +10,9 @@
   <meta name="application-name" content="DashboardHub PipelineDashboard">
   <meta name="theme-color" content="#1976d2">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/favicon.ico">
+  <meta property="og:title" content="PipelineDashboard">
+
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -10,24 +10,27 @@
   <meta name="application-name" content="DashboardHub PipelineDashboard">
   <meta name="theme-color" content="#1976d2">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/logo-horizontal-std-2567x580.png">
+  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png">
+  <meta property="og:image:width" content="400" />
+  <meta property="og:image:height" content="300" />
   <meta property="og:title" content="PipelineDashboard">
 
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script>
     (function (i, s, o, g, r, a, m) {
-                i['GoogleAnalyticsObject'] = r;
-                i[r] = i[r] || function () {
-                    (i[r].q = i[r].q || []).push(arguments);
-                };
-                i[r].l = 1 * new Date();
-                a = s.createElement(o);
-                m = s.getElementsByTagName(o)[0];
-                a.async = 1;
-                a.src = g;
-                m.parentNode.insertBefore(a, m);
-            })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+      i['GoogleAnalyticsObject'] = r;
+      i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments);
+      };
+      i[r].l = 1 * new Date();
+      a = s.createElement(o);
+      m = s.getElementsByTagName(o)[0];
+      a.async = 1;
+      a.src = g;
+      m.parentNode.insertBefore(a, m);
+    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+
   </script>
 
 

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -11,18 +11,20 @@
   <meta name="theme-color" content="#1976d2">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
- <!-- Facbook meta tags -->
+  <!-- Facbook meta tags -->
   <meta property="og:title" content="DashboardHub">
   <meta property="og:image" content="https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png">
   <meta property="og:image:width" content="200">
   <meta property="og:image:height" content="200">
 
   <!-- Twitter meta tags -->
+  <meta property="twitter:site" content="DashboardHub">
+  <meta property="twitter:creator" content="DashboardHub">
+  <meta property="twitter:card" content="DashboardHubLogo">
   <meta property="twitter:title" content="DashboardHub">
   <meta property="twitter:image:src" content="https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png">
   <meta property="twitter:image:width" content="200">
   <meta property="twitter:image:height" content="200">
-
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -14,14 +14,14 @@
   <!-- Facbook meta tags -->
   <meta property="og:title" content="DashboardHub">
   <meta property="og:type" content="article">
-  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png">
+  <meta property="og:image" content="https://cdn.dashboardhub.io/mascot/21-240x240.png">
 
   <!-- Twitter meta tags -->
   <meta property="twitter:site" content="DashboardHub">
   <meta property="twitter:creator" content="DashboardHub">
   <meta property="twitter:card" content="summary">
   <meta property="twitter:title" content="DashboardHub">
-  <meta property="twitter:image:src" content="https://cdn.dashboardhub.io/logo/icon-only-orange-1216x1160.png">
+  <meta property="twitter:image:src" content="https://cdn.dashboardhub.io/mascot/21-240x240.png">
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -13,14 +13,14 @@
 
   <!-- Facbook meta tags -->
   <meta property="og:title" content="DashboardHub">
-  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/icon-only-orange-120x120.png">
+  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/logo-horizontal-std-2567x580.png">
 
   <!-- Twitter meta tags -->
   <meta property="twitter:site" content="DashboardHub">
   <meta property="twitter:creator" content="DashboardHub">
   <meta property="twitter:card" content="summary_large_image">
   <meta property="twitter:title" content="DashboardHub">
-  <meta property="twitter:image:src" content="https://cdn.dashboardhub.io/logo/icon-only-orange-120x120.png">
+  <meta property="twitter:image:src" content="https://cdn.dashboardhub.io/logo/logo-horizontal-std-2567x580.png">
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -10,7 +10,7 @@
   <meta name="application-name" content="DashboardHub PipelineDashboard">
   <meta name="theme-color" content="#1976d2">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/favicon.ico">
+  <meta property="og:image" content="https://cdn.dashboardhub.io/logo/logo-horizontal-std.svg">
   <meta property="og:title" content="PipelineDashboard">
 
 


### PR DESCRIPTION
closes #627 

### Notes

A summary of what was achieved in this PR

- [ ] Added the Support for updating meta tags for project dashboard page.
- [ ] Updated og:title and og:image meta tags dynamically via meta service


Before
![image (1)](https://user-images.githubusercontent.com/10898595/66319231-6564f180-e93a-11e9-89fe-7393911b2d2d.png)


After:
![image](https://user-images.githubusercontent.com/10898595/66319174-46665f80-e93a-11e9-9db4-71fdc4f16ca6.png)

Twitter:
![image](https://user-images.githubusercontent.com/10898595/66408875-5d29b680-ea0d-11e9-9370-b8f902373b49.png)

